### PR TITLE
Edit order forms

### DIFF
--- a/application/src/components/alter-orders/alter.css
+++ b/application/src/components/alter-orders/alter.css
@@ -1,0 +1,9 @@
+.alter-group {
+    margin-bottom: 0.6vh;
+}
+
+.alter-button {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+}

--- a/application/src/components/alter-orders/deleteOrder.js
+++ b/application/src/components/alter-orders/deleteOrder.js
@@ -1,0 +1,45 @@
+import React, { Component } from 'react';
+import { SERVER_IP } from '../../private';
+import './alter.css';
+
+const DELETE_ORDER_URL = `${SERVER_IP}/api/delete-order`
+
+class DeleteOrder extends Component {
+    constructor(props) {
+        super(props);
+        this.closeCallback = props.closeCallback.bind(this);
+        this.fetchCallback = props.fetchCallback.bind(this);
+        this.onDeleteClick = this.onDeleteClick.bind(this);
+    }
+
+    onDeleteClick () {
+        fetch(DELETE_ORDER_URL, {
+            method: 'POST',
+            body: JSON.stringify({
+                id: this.props.order._id
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(raw => raw.json())
+        .then(res => {
+            this.fetchCallback();
+            this.closeCallback();
+        })
+        .catch(err => console.log("Something went wront with deleting the order", err));
+    }
+
+    render() {
+        return (
+            <div>
+                <p>Are you sure you'd like to delete this order?</p>
+                <button onClick={this.onDeleteClick} className="alter-button btn btn-danger">
+                    Delete
+                </button>
+            </div>
+        );
+    }
+}
+
+export default DeleteOrder;

--- a/application/src/components/alter-orders/editOrder.js
+++ b/application/src/components/alter-orders/editOrder.js
@@ -33,7 +33,8 @@ class EditOrder extends Component {
 
     onFormChange(name, value) {
         console.log(`NEW STATE: {${name}: ${value} }}`)
-        this.setState({ ...this.state, [name]: value })
+        let correctedValue = name == "ordered_by" ? value == "" ? this.state.prev_ordered_by : value : value
+        this.setState({ ...this.state, [name]: correctedValue })
     }
 
     onEditSubmit(e) {
@@ -43,7 +44,7 @@ class EditOrder extends Component {
             method: 'POST',
             body: JSON.stringify({
                 id: this.props.order._id,
-                ordered_by: this.props.ordered_by,
+                ordered_by: this.state.ordered_by,
                 order_item: this.state.order_item,
                 quantity: this.state.quantity
             }),
@@ -88,7 +89,8 @@ class EditOrder extends Component {
                     </div>
                 </div>
                 <div className="alter-group">
-                    <input onChange={(e) => this.onFormChange("ordered_by", e.target.value)} />
+                    <strong>Update Email</strong>
+                    <input placeholder={this.state.prev_ordered_by} onChange={(e) => this.onFormChange("ordered_by", e.target.value)} />
                 </div>
                 <div className="mt-3">
                     <button

--- a/application/src/components/alter-orders/editOrder.js
+++ b/application/src/components/alter-orders/editOrder.js
@@ -1,0 +1,106 @@
+import React, { Component } from 'react';
+import { SERVER_IP } from '../../private';
+import './alter.css'
+
+const EDIT_ORDER_URL = `${SERVER_IP}/api/edit-order`
+
+class EditOrder extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            order_item: props.order.order_item,
+            quantity: props.order.quantity,
+            ordered_by: props.order.ordered_by,
+            prev_item: props.order.order_item,
+            prev_quantity: props.order.quantity,
+            prev_ordered_by: props.order.ordered_by
+        }
+        this.closePopup = props.closeCallback.bind(this);
+        this.onFormChange = this.onFormChange.bind(this);
+        this.onEditSubmit = this.onEditSubmit.bind(this);
+        this.hasChanged = this.hasChanged.bind(this);
+    }
+
+    hasChanged() {
+        let isDisabled = true;
+        if (this.state.prev_item !== this.state.order_item || this.state.quantity !== this.state.prev_quantity || this.state.ordered_by !== this.state.prev_ordered_by) {
+            console.log('1')
+            isDisabled = false;
+        }
+        console.log(isDisabled)
+        return isDisabled
+    }
+
+    onFormChange(name, value) {
+        console.log(`NEW STATE: {${name}: ${value} }}`)
+        this.setState({ ...this.state, [name]: value })
+    }
+
+    onEditSubmit(e) {
+        e.preventDefault();
+        console.log(this.state);
+        fetch(EDIT_ORDER_URL, {
+            method: 'POST',
+            body: JSON.stringify({
+                id: this.props.order._id,
+                ordered_by: this.props.ordered_by,
+                order_item: this.state.order_item,
+                quantity: this.state.quantity
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+            .then(res => res.json())
+            .then(response => {
+                console.log("Edit Successfully Submitted: \n", JSON.stringify(response));
+                this.props.fetchCallback();
+                this.props.closeCallback();
+            })
+            .catch(err => console.log("An Error Occurred with Editing the Order:\n", err));
+    }
+
+    render() {
+        return (
+            <div>
+                <div className="alter-group">
+                    <strong>Select Item</strong>
+                    <select onChange={(e) => this.onFormChange("order_item", e.target.value)}>
+                        <option value="" selected disabled hidden>Choose New Menu Item</option>
+                        <option disabled={this.state.prev_item === "Soup of the Day"} value="Soup of the Day">Soup of the Day</option>
+                        <option disabled={this.state.prev_item === "Linguini With White Wine Sauce"} value="Linguini With White Wine Sauce">Linguini With White Wine Sauce</option>
+                        <option disabled={this.state.prev_item === "Eggplant and Mushroom Panini"} value="Eggplant and Mushroom Panini">Eggplant and Mushroom Panini</option>
+                        <option disabled={this.state.prev_item === "Chili Con Carne"} value="Chili Con Carne">Chili Con Carne</option>
+                    </select>
+                </div>
+                <div className="alter-group">
+                    <strong>Select quantity</strong>
+                    <div>
+                        <select onChange={(e) => this.onFormChange("quantity", e.target.value)}>
+                            <option value="" selected disabled hidden>Choose New Quantity</option>
+                            <option disabled={String(this.state.prev_quantity) === "1"} value="1">1</option>
+                            <option disabled={String(this.state.prev_quantity) === "2"} value="2">2</option>
+                            <option disabled={String(this.state.prev_quantity) === "3"} value="3">3</option>
+                            <option disabled={String(this.state.prev_quantity) === "4"} value="4">4</option>
+                            <option disabled={String(this.state.prev_quantity) === "5"} value="5">5</option>
+                            <option disabled={String(this.state.prev_quantity) === "6"} value="6">6</option>
+                        </select>
+                    </div>
+                </div>
+                <div className="alter-group">
+                    <input onChange={(e) => this.onFormChange("ordered_by", e.target.value)} />
+                </div>
+                <div className="mt-3">
+                    <button
+                        disabled={this.hasChanged()}
+                        onClick={this.onEditSubmit}
+                        className="alter-button btn btn-success">
+                        Edit
+                    </button>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default EditOrder;

--- a/application/src/components/common/popup.css
+++ b/application/src/components/common/popup.css
@@ -1,0 +1,23 @@
+.popup {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 280px;
+    height: fit-content;
+    min-height: 150px;
+    margin-left: -140px;
+    margin-top: -100px;
+    padding-left: 5px;
+    border: 2px solid gray;
+    border-radius: 1rem;
+    background-color: rgb(228, 225, 225);
+}
+
+.popup-header {
+    font-size: 1.5rem;
+}
+
+.popup-content {
+    padding-top: 5px;
+    padding-left: 3px;
+}

--- a/application/src/components/common/popup.js
+++ b/application/src/components/common/popup.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import './popup.css';
+
+const Popup = props => {
+    return (
+        <div className="popup" onClick={(e) => e.stopPropagation()}>
+            <div className="popup-content">
+                {props.children}
+            </div>
+        </div>
+    );
+}
+
+export default Popup;

--- a/application/src/components/common/template.js
+++ b/application/src/components/common/template.js
@@ -4,7 +4,7 @@ import './template.css';
 
 const Template = props => {
     return (
-        <div className="bg-layer">
+        <div className="bg-layer" onClick={props.closeCallback}>
             <div className="fg-layer">
                 <label className="logo">Bruce's Diner</label>
                 <Nav />

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -3,12 +3,44 @@ import { Template } from '../../components';
 import { SERVER_IP } from '../../private';
 import './viewOrders.css';
 
+import Popup from '../common/popup';
+import EditOrder from '../alter-orders/editOrder';
+import DeleteOrder from '../alter-orders/deleteOrder';
+
 class ViewOrders extends Component {
-    state = {
-        orders: []
+    constructor(props) {
+        super(props);
+        this.deleteOrder = this.deleteOrder.bind(this);
+        this.editOrder = this.editOrder.bind(this);
+        this.closePopup = this.closePopup.bind(this);
+        this.fetchOrders = this.fetchOrders.bind(this);
     }
 
-    componentDidMount() {
+    state = {
+        orders: [],
+        selectedOrder: null,
+        showEdit: false,
+        showDelete: false
+    }
+
+    deleteOrder(order) {
+        console.log("Delete order: ", order);
+        this.setState({ ...this.state, selectedOrder: order, showDelete: true });
+    }
+
+    editOrder(order) {
+        console.log("Edit order: ", order);
+        this.setState({ ...this.state, selectedOrder: order, showEdit: true });
+    }
+
+    closePopup() {
+        console.log("Close the popup")
+        if (this.state.showEdit || this.state.showDelete) {
+            this.setState({ ...this.state, selectedOrder: null, showDelete: false, showEdit: false });
+        }
+    }
+
+    fetchOrders() {
         fetch(`${SERVER_IP}/api/current-orders`)
             .then(response => response.json())
             .then(response => {
@@ -20,9 +52,13 @@ class ViewOrders extends Component {
             });
     }
 
+    componentDidMount() {
+        this.fetchOrders();
+    }
+
     render() {
         return (
-            <Template>
+            <Template closeCallback={this.closePopup}>
                 <div className="container-fluid">
                     {this.state.orders.map(order => {
                         const createdDate = new Date(order.createdAt);
@@ -37,13 +73,39 @@ class ViewOrders extends Component {
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">
-                                     <button className="btn btn-success">Edit</button>
-                                     <button className="btn btn-danger">Delete</button>
+                                    <button 
+                                        className="btn btn-success" 
+                                        onClick={() => this.editOrder(order)}
+                                        disabled={this.state.showDelete || this.state.showEdit}>
+                                        Edit
+                                    </button>
+                                    <button
+                                        className="btn btn-danger" 
+                                        onClick={() => this.deleteOrder(order)}
+                                        disabled={this.state.showDelete || this.state.showEdit}>
+                                        Delete
+                                    </button>
                                  </div>
                             </div>
                         );
                     })}
                 </div>
+                <>
+                    {this.state.showEdit && (
+                        <Popup>
+                            <strong className="popup-header">Edit Order</strong>
+                            <EditOrder order={this.state.selectedOrder} closeCallback={this.closePopup} fetchCallback={this.fetchOrders} />
+                        </Popup>
+                    )}
+                </>
+                <>
+                    {this.state.showDelete && (
+                        <Popup>
+                            <strong className="popup-header">Delete Order</strong>
+                            <DeleteOrder order={this.state.selectedOrder} closeCallback={this.closePopup} fetchCallback={this.fetchOrders} />
+                        </Popup>
+                    )}
+                </>
             </Template>
         );
     }

--- a/application/src/private.js
+++ b/application/src/private.js
@@ -1,3 +1,3 @@
 const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
 
-export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) < 0 ? 'http://localhost:4000' : 'http://192.168.99.100:4000';
+export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) < 0 ? 'http://localhost:4000' : 'http://127.0.0.1:4000';


### PR DESCRIPTION
Added the following:

<Popup> tags that as wrappers for the edit and delete forms. The popup tag closes on parent click.
<EditOrder> A form to edit each order, which prevents submission of null or unchanged data.
<DeleteOrder> A popup to confirm order deletion.

Both Edit and Delete forms perform "live refresh" on submit, using callbacks to re-load the updated order data from Mongo into the viewOrder component, and to close the popup.
