### PR TITLE
Time format

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -25,7 +25,7 @@ class ViewOrders extends Component {
             <Template>
                 <div className="container-fluid">
                     {this.state.orders.map(order => {
-                        const createdDate = new Date(order.createdAt);
+                        const createdDate = new Date(order.createdAt).toTimeString().split(' ')[0];
                         return (
                             <div className="row view-order-container" key={order._id}>
                                 <div className="col-md-4 view-order-left-col p-3">
@@ -33,7 +33,7 @@ class ViewOrders extends Component {
                                     <p>Ordered by: {order.ordered_by || ''}</p>
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
-                                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                                    <p>Order placed at {createdDate}</p>
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">

--- a/application/src/private.js
+++ b/application/src/private.js
@@ -1,3 +1,3 @@
 const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
 
-export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) < 0 ? 'http://localhost:4000' : 'http://192.168.99.100:4000';
+export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) < 0 ? 'http://localhost:4000' : 'http://127.0.0.1:4000';


### PR DESCRIPTION
The custom code to split the date into hour:minute:second was replaced with the Date.toTimeString() method to auto format the date into HH:MM:SS (of course with the help of .split(" ")[0] to get the first part of the return from the toTimeString() method). 

I can't really take credit for this fix; it was all thanks to stack overflow ;)